### PR TITLE
Fixes crash when trying to use a password with the script.

### DIFF
--- a/add-opt-in.py
+++ b/add-opt-in.py
@@ -110,7 +110,7 @@ def outputTelemetryTag(o, passwordClear):
     
     # Password
     if passwordClear:
-        output(o, passwordDigest)
+        o.write(passwordDigest)
 
 ####################################
 # main()


### PR DESCRIPTION
output() doesn't exist anymore. old artifact from previous script.
